### PR TITLE
Full Vuex support with enhanced Counter.vue example and test spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,11 @@ See examples below for details.
 See [cypress/integration/options-spec.js](cypress/integration/options-spec.js)
 for examples of options.
 
-* `vue` - path or URL to the Vue library to load. By default, will
-try to load `../node_modules/vue/dist/vue.js`, but you can pass your
-own path or URL.
+* `mountId` - specify root Vue app mount element ID. Defaults to `app`.
 
 ```js
 const options = {
-  vue: 'https://unpkg.com/vue'
+  mountId: 'rootApp'  // div#rootApp
 }
 beforeEach(mountVue(/* my Vue code */, options))
 ```
@@ -71,12 +69,25 @@ beforeEach(mountVue(/* my Vue code */, options))
 place to load additional libraries, polyfills and styles.
 
 ```js
-const vue = '../node_modules/vue/dist/vue.js'
+const polyfill = '../node_modules/mypolyfill/dist/polyfill.js'
 const options = {
-  html: `<div id="app"></div><script src="${vue}"></script>`
+  html: `<div id="app"></div><script src="${polyfill}"></script>`
 }
 beforeEach(mountVue(/* my Vue code */, options))
 ```
+
+* `vue` **[DEPRECATED]** - path or URL to the Vue library to load. By default, will
+try to load `../node_modules/vue/dist/vue.js`, but you can pass your
+own path or URL.
+
+```js
+const options = {
+  vue: 'https://unpkg.com/vue'
+}
+beforeEach(mountVue(/* my Vue code */, options))
+```
+> #### Deprecation Warning
+> `vue` option has been deprecated. `node_modules/vue/dist/vue` is always used.
 
 ### Global Vue extensions
 

--- a/components/.babelrc
+++ b/components/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-object-rest-spread"
+  ]
+}

--- a/components/Counter.vue
+++ b/components/Counter.vue
@@ -1,6 +1,6 @@
 <template>
-  <div id="app">
-    Clicked: {{ $store.state.count }} times, count is {{ evenOrOdd }}.
+  <div>
+    Clicked: {{ $store.state.count }} times, count is {{ $store.getters.evenOrOdd }}.
     <button @click="increment">+</button>
     <button @click="decrement">-</button>
     <button @click="incrementIfOdd">Increment if odd</button>

--- a/components/Counter.vue
+++ b/components/Counter.vue
@@ -1,24 +1,31 @@
 <template>
   <div>
-    Clicked: {{ $store.state.count }} times, count is {{ $store.getters.evenOrOdd }}.
+    Clicked: {{ count }} times, count is {{ evenOrOdd }}.<br>
     <button @click="increment">+</button>
     <button @click="decrement">-</button>
     <button @click="incrementIfOdd">Increment if odd</button>
     <button @click="incrementAsync">Increment async</button>
+    <br><br>
+    <span>Set Count: </span>
+    <input type="number" :value="count" @input="set($event.target.value || 0)">
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapState, mapGetters, mapMutations, mapActions } from 'vuex'
 export default {
-  computed: mapGetters([
-    'evenOrOdd'
-  ]),
-  methods: mapActions([
-    'increment',
-    'decrement',
-    'incrementIfOdd',
-    'incrementAsync'
-  ])
+  computed: {
+    ...mapState(['count']),
+    ...mapGetters(['evenOrOdd'])
+  },
+  methods: {
+    ...mapMutations(['set']),
+    ...mapActions([
+      'increment',
+      'decrement',
+      'incrementIfOdd',
+      'incrementAsync'
+    ])
+  }
 }
 </script>

--- a/components/store.js
+++ b/components/store.js
@@ -14,6 +14,9 @@ const state = {
 // mutations must be synchronous and can be recorded by plugins
 // for debugging purposes.
 const mutations = {
+  set (state, value) {
+    state.count = value
+  },
   increment (state) {
     state.count++
   },

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "viewportWidth": 300,
-  "viewportHeight": 100,
+  "viewportHeight": 120,
   "videoRecording": false,
   "projectId": "134ej7"
 }

--- a/cypress/integration/counter-vuex-spec.js
+++ b/cypress/integration/counter-vuex-spec.js
@@ -26,12 +26,6 @@ describe('Vuex Counter', () => {
   // initialize a fresh Vue app before each test
   beforeEach(mountVue({template, store}, {extensions}))
 
-  const getCount = () =>
-    Cypress.vue.$store.state.count
-
-  const setCount = value =>
-    Cypress.vue.$set(Cypress.vue.$store.state, 'count', value)
-
   it('starts with zero', () => {
     cy.contains('0 times')
   })

--- a/cypress/integration/counter-vuex-spec.js
+++ b/cypress/integration/counter-vuex-spec.js
@@ -19,9 +19,8 @@ describe('Vuex Counter', () => {
   const getCount = () =>
     Cypress.vue.$store.state.count
 
-  const setCount = value => {
-    Cypress.vue.$store.state.count = value
-  }
+  const setCount = value =>
+    Cypress.vue.$set(Cypress.vue.$store.state, 'count', value)
 
   it('starts with zero', () => {
     cy.contains('0 times')
@@ -45,8 +44,8 @@ describe('Vuex Counter', () => {
   })
 
   it('asynchronously increments counter', () => {
-    let count = getCount()
+    const count = getCount()
     cy.contains('button', 'Increment async').click()
-    cy.contains(`${count++} times`)
+    cy.contains(`${count + 1} times`)
   })
 })

--- a/cypress/integration/counter-vuex-spec.js
+++ b/cypress/integration/counter-vuex-spec.js
@@ -7,20 +7,24 @@ import mountVue from '../..'
 
 /* eslint-env mocha */
 describe('Vuex Counter', () => {
+
+  // configure component
   const extensions = {
     plugins: [Vuex],
     components: {
-      counter: Counter
-    },
+      Counter
+    }
   }
+
+  // define component template
   const template = '<counter />'
+
+  // define count get and set helpers
+  const getCount = () => Cypress.vue.$store.state.count
+  const setCount = value => Cypress.vue.$store.commit('set', value)
+
+  // initialize a fresh Vue app before each test
   beforeEach(mountVue({template, store}, {extensions}))
-
-  const getCount = () =>
-    Cypress.vue.$store.state.count
-
-  const setCount = value =>
-    Cypress.vue.$set(Cypress.vue.$store.state, 'count', value)
 
   it('starts with zero', () => {
     cy.contains('0 times')
@@ -37,15 +41,30 @@ describe('Vuex Counter', () => {
   })
 
   it('increments the counter if count is odd', () => {
-    setCount(3)
+    setCount(3)  // start with an odd number
     cy.contains('odd')
-    cy.contains('button', 'Increment if odd').click()
+    cy.contains('button', 'Increment if odd').as('btn').click()
+    cy.contains('even')
+    cy.get('@btn').click()
     cy.contains('even')
   })
 
   it('asynchronously increments counter', () => {
     const count = getCount()
+    // increment mutation is delayed by 1 second
+    // Cypress waits 4 seconds by default
     cy.contains('button', 'Increment async').click()
     cy.contains(`${count + 1} times`)
+  })
+
+  it('count is zero when input is cleared', () => {
+    cy.get('input').type(`{selectall}{backspace}`)
+    cy.contains('0 times')
+  }),
+
+  it('set count via input field', () => {
+    const count = 42
+    cy.get('input').type(`{selectall}{backspace}${count}`)
+    cy.contains(`${count} times`)
   })
 })

--- a/cypress/integration/counter-vuex-spec.js
+++ b/cypress/integration/counter-vuex-spec.js
@@ -2,11 +2,13 @@
 // https://github.com/vuejs/vuex/tree/dev/examples/counter
 import Counter from '../../components/Counter.vue'
 import store from '../../components/store'
-const mountVue = require('../..')
+import Vuex from 'vuex'
+import mountVue from '../..'
 
 /* eslint-env mocha */
 describe('Vuex Counter', () => {
-  const extensions = {    
+  const extensions = {
+    plugins: [Vuex],
     components: {
       counter: Counter
     },
@@ -14,7 +16,37 @@ describe('Vuex Counter', () => {
   const template = '<counter />'
   beforeEach(mountVue({template, store}, {extensions}))
 
+  const getCount = () =>
+    Cypress.vue.$store.state.count
+
+  const setCount = value => {
+    Cypress.vue.$store.state.count = value
+  }
+
   it('starts with zero', () => {
-    cy.contains('button', '0')
+    cy.contains('0 times')
+  })
+
+  it('increments the counter on click of "+"', () => {
+    cy.contains('button', '+').click()
+    cy.contains('1 times')
+  })
+
+  it('decrements the counter on click of "-"', () => {
+    cy.contains('button', '-').click()
+    cy.contains('0 times')
+  })
+
+  it('increments the counter if count is odd', () => {
+    setCount(3)
+    cy.contains('odd')
+    cy.contains('button', 'Increment if odd').click()
+    cy.contains('even')
+  })
+
+  it('asynchronously increments counter', () => {
+    let count = getCount()
+    cy.contains('button', 'Increment async').click()
+    cy.contains(`${count++} times`)
   })
 })

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "generateNotes": "github-post-release"
   },
   "devDependencies": {
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
     "ban-sensitive-files": "1.9.2",
     "css-loader": "0.28.7",
     "cypress": "1.4.1",
@@ -86,7 +87,6 @@
     "semantic-action": "1.1.0",
     "simple-commit-message": "3.3.2",
     "standard": "10.0.3",
-    "vue": "2.5.13",
     "vue-loader": "13.6.1",
     "vue-template-compiler": "2.5.13",
     "vuex": "3.0.1"
@@ -100,6 +100,7 @@
   },
   "dependencies": {
     "@cypress/webpack-preprocessor": "1.1.2",
-    "common-tags": "1.6.0"
+    "common-tags": "1.6.0",
+    "vue": "2.5.13"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,16 @@
+const Vue = require('vue/dist/vue')
 const { stripIndent } = require('common-tags')
+
+// mountVue options
+const defaultOptions = ['html', 'vue', 'base', 'mountId', 'extensions']
+
+// default mount point element ID for root Vue instance
+const defaultMountId = 'app'
+
+const parentDocument = window.parent.document
+const projectName = Cypress.config('projectName')
+const appIframeId = `Your App: '${projectName}'`
+const appIframe = parentDocument.getElementById(appIframeId)
 
 // having weak reference to styles prevents garbage collection
 // and "losing" styles when the next test starts
@@ -23,10 +35,6 @@ const copyStyles = component => {
     return
   }
 
-  const parentDocument = window.parent.document
-  const projectName = Cypress.config('projectName')
-  const appIframeId = `Your App: '${projectName}'`
-  const appIframe = parentDocument.getElementById(appIframeId)
   const head = appIframe.contentDocument.querySelector('head')
   styles.forEach(style => {
     head.appendChild(style)
@@ -42,59 +50,20 @@ const deleteCachedConstructors = component => {
   Cypress._.values(component.components).forEach(deleteConstructor)
 }
 
-const getVuePath = options =>
-  options.vue || options.vuePath || '../node_modules/vue/dist/vue.js'
-
-const getVuexPath = options => options.vuex || options.vuexPath
-
 const getPageHTML = options => {
-  if (options.html) {
-    return options.html
-  }
-  const vue = getVuePath(options)
-  let vuex = getVuexPath(options)
-  if (vuex) {
-    vuex = `<script src="${vuex}"></script>`
-  }
-
-  // note: add "base" tag to force loading static assets
-  // from the server, not from the "spec" file URL
-  if (options.base) {
-    if (vue.startsWith('.')) {
-      console.error(
-        'You are using base tag %s and relative Vue path %s',
-        options.base,
-        vue
-      )
-      console.error('the relative path might NOT work')
-      console.error(
-        'maybe pass Vue url using "https://unpkg.com/vue/dist/vue.js"'
-      )
-    }
-    return stripIndent`
-      <html>
-        <head>
-          <base href="${options.base}" />
-        </head>
-        <body>
-          <div id="app"></div>
-          <script src="${vue}"></script>
-        </body>
-      </html>
-    `
-  }
-
-  const vueHtml = stripIndent`
+  return (
+    options.html ||
+    stripIndent`
     <html>
-      <head></head>
+      <head>
+        ${options.base ? `<base href="${options.base}" />` : ''}
+      </head>
       <body>
-        <div id="app"></div>
-        <script src="${vue}"></script>
-        ${vuex || ''}
+        <div id="${options.mountId || defaultMountId}"></div>
       </body>
     </html>
   `
-  return vueHtml
+  )
 }
 
 const registerGlobalComponents = (Vue, options) => {
@@ -128,8 +97,7 @@ const installMixins = (Vue, options) => {
   }
 }
 
-const isOptionName = name =>
-  ['vue', 'html', 'vuePath', 'base', 'extensions'].includes(name)
+const isOptionName = name => defaultOptions.includes(name)
 
 const isOptions = object => Object.keys(object).every(isOptionName)
 
@@ -137,9 +105,8 @@ const isConstructor = object => object && object._compiled
 
 const hasStore = ({ store }) => store && store._vm
 
-const forEachValue = (obj, fn) => {
+const forEachValue = (obj, fn) =>
   Object.keys(obj).forEach(key => fn(obj[key], key))
-}
 
 const resetStoreVM = (Vue, { store }) => {
   // bind store public getters
@@ -177,38 +144,51 @@ const mountVue = (component, optionsOrProps = {}) => () => {
     props = optionsOrProps
   }
 
-  const vueHtml = getPageHTML(options)
-  const document = cy.state('document')
-  document.write(vueHtml)
-  document.close()
+  // display deprecation warnings
+  if (options.vue) {
+    console.warn(stripIndent`
+      [DEPRECATION]: 'vue' option has been deprecated.
+      'node_modules/vue/dis/vue' is always used.
+      Please remove it from your 'mountVue' options.`)
+  }
 
-  // TODO: do not log out "its(Vue)" command
-  // but it currently does not support it
-  return cy
-    .window({ log: false })
-    .its('Vue')
-    .then(Vue => {
-      // refresh inner Vue instance of Vuex store
-      if (hasStore(component)) {
-        component.store = resetStoreVM(Vue, component)
-      }
-      installMixins(Vue, options)
-      installPlugins(Vue, options)
-      registerGlobalComponents(Vue, options)
-      deleteCachedConstructors(component)
+  // insert base app template
+  const doc = appIframe.contentDocument
+  doc.write(getPageHTML(options))
+  doc.close()
 
-      if (isConstructor(component)) {
-        const Cmp = Vue.extend(component)
-        Cypress.vue = new Cmp(props).$mount('#app')
-        copyStyles(Cmp)
-      } else {
-        const allOptions = Object.assign({}, component, { el: '#app' })
-        Cypress.vue = new Vue(allOptions)
-        copyStyles(component)
-      }
+  // get root Vue mount element
+  const mountId = options.mountId || defaultMountId
+  const el = doc.getElementById(mountId)
 
-      return Cypress.vue
-    })
+  // set global Vue instance:
+  // 1. convenience for debugging in DevTools
+  // 2. some libraries might check for this global
+  appIframe.contentWindow.Vue = Vue
+
+  // refresh inner Vue instance of Vuex store
+  if (hasStore(component)) {
+    component.store = resetStoreVM(Vue, component)
+  }
+
+  // setup Vue instance
+  installMixins(Vue, options)
+  installPlugins(Vue, options)
+  registerGlobalComponents(Vue, options)
+  deleteCachedConstructors(component)
+
+  // create root Vue component
+  // and make it accessible via Cypress.vue
+  if (isConstructor(component)) {
+    const Cmp = Vue.extend(component)
+    Cypress.vue = new Cmp(props).$mount(el)
+    copyStyles(Cmp)
+  } else {
+    Cypress.vue = new Vue(component).$mount(el)
+    copyStyles(component)
+  }
+
+  return cy.wrap(Cypress.vue)
 }
 
 module.exports = mountVue


### PR DESCRIPTION
This request follows up bahmutov/cypress-vue-unit-test#13 to finalize Vuex support. It works now @bahmutov 🙂

The solution required refactoring how Vue is initialized with in the app iframe. For increased thoroughness and confidence I've update the Counter example to utilize all the primary features of Vuex, and I've updated the test spec accordingly. 

<img width="952" alt="vuex counter test" src="https://user-images.githubusercontent.com/334337/35486151-d46903f8-041e-11e8-873a-2bdc46325c47.png">
