### PR TITLE
Add Vue Router Example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 [Bundling](#bundling)
 - [Short Way](#short-way)
 - [Manual](#manual)
+
 [FAQ](#faq)
 
 <a name="install"/>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@
 
 * How is this different from [vue-test-utils](https://vue-test-utils.vuejs.org/en/)? It is similar in functionality BUT runs the component in the real browser with full power of Cypress E2E test runner: [live GUI, full API, screen recording, CI support, cross-platform](https://www.cypress.io/features/).
 
+## Table of Contents
+
+[Install](#install)
+
+[Use](#use)
+- [Options](#options)
+- [Global Vue Extensions](#global-vue-extensions)
+- [The Intro Example](#intro-example)
+- [The List Example](#list-example)
+- [Handling User Input](#handling-user-input)
+- [Component Example](#component-example)
+- [Spying Example](#spying-example)
+- [XHR Spying and Stubbing](#xhr-spying-stubbing)
+- [Spying On `window.alert`](#spying-window-alert)
+
+[Bundling](#bundling)
+- [Short Way](#short-way)
+- [Manual](#manual)
+[FAQ](#faq)
+
+<a name="install"/>
+
 ## Install
 
 Requires [Node](https://nodejs.org/en/) version 6 or above.
@@ -22,6 +44,8 @@ Requires [Node](https://nodejs.org/en/) version 6 or above.
 ```sh
 npm install --save-dev cypress cypress-vue-unit-test
 ```
+
+<a name="use"/>
 
 ## Use
 
@@ -39,6 +63,8 @@ describe('My Vue', () => {
 ```
 
 See examples below for details.
+
+<a name="options"/>
 
 ### Options
 
@@ -77,6 +103,8 @@ const options = {
 }
 beforeEach(mountVue(/* my Vue code */, options))
 ```
+
+<a name="global-vue-extensions"/>
 
 ### Global Vue extensions
 
@@ -150,6 +178,8 @@ it('calls mixin "created" method', () => {
 See [Vue global mixin docs](https://vuejs.org/v2/guide/mixins.html#Global-Mixin)
 and [mixin-spec.js](cypress/integration/mixin-spec.js)
 
+<a name="intro-example"/>
+
 ### The intro example
 
 Take a look at the first Vue v2 example:
@@ -215,6 +245,8 @@ the reference `Cypress.vue.$data` and via GUI. The full power of the
 
 ![Hello world tested](images/spec.png)
 
+<a name="list-example"/>
+
 ### The list example
 
 There is a list example next in the Vue docs.
@@ -279,6 +311,8 @@ describe('Declarative rendering', () => {
 ```
 
 ![List tested](images/list-spec.png)
+
+<a name="handling-user-input"/>
 
 ### Handling User Input
 
@@ -346,6 +380,8 @@ because it is really running!
 
 ![Reverse input](images/reverse-spec.gif)
 
+<a name="component-example"/>
+
 ### Component example
 
 Let us test a complex example. Let us test a [single file Vue component](https://vuejs.org/v2/guide/single-file-components.html). Here is the [Hello.vue](Hello.vue) file
@@ -400,6 +436,8 @@ describe('Several components', () => {
   })
 })
 ```
+
+<a name="spying-example"/>
 
 ### Spying example
 
@@ -472,6 +510,8 @@ and is emitting an event.
 
 [cypress.io]: https://www.cypress.io/
 
+<a name="xhr-spying-stubbing"/>
+
 ### XHR spying and stubbing
 
 The mount function automatically wraps XMLHttpRequest giving you an ability to intercept XHR requests your component might do. For full documentation see [Network Requests](https://on.cypress.io/network-requests). In this repo see [components/AjaxList.vue](components/AjaxList.vue) and the corresponding tests [cypress/integration/ajax-list-spec.js](cypress/integration/ajax-list-spec.js).
@@ -501,13 +541,19 @@ it('can display mock XHR response', () => {
 })
 ```
 
+<a name="spying-window-alert"/>
+
 ### Spying on `window.alert`
 
 Calls to `window.alert` are automatically recorded, but do not show up. Instead you can spy on them, see [AlertMessage.vue](components/AlertMessage.vue) and its test [cypress/integration/alert-spec.js](cypress/integration/alert-spec.js)
 
+<a name="bundling"/>
+
 ## Bundling
 
 How do we load this Vue file into the testing code? Using webpack preprocessor.
+
+<a name="short-way"/>
 
 ### Short way
 
@@ -526,6 +572,8 @@ module.exports = on => {
 ```
 
 Cypress should be able to import `.vue` files in the tests
+
+<a name="manual"/>
 
 ### Manual
 
@@ -581,6 +629,8 @@ describe('Hello.vue', () => {
   })
 })
 ```
+
+<a name="#faq"/>
 
 ## FAQ
 

--- a/components/PizzaShop/Home.vue
+++ b/components/PizzaShop/Home.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="shop-home">
+    <router-link
+      :to="{ name: 'order' }"
+      tag="button"
+      class="order"
+    >
+      Place Your Order
+    </router-link>
+    <br>
+    <h4>Or select a popular option:</h4>
+    <router-link
+      :to="{ name: 'order', params: { preset: 'veggie' } }"
+      class="order-veggie"
+    >
+      🥗 Veggie
+    </router-link><br>
+    <router-link
+      :to="{ name: 'order', params: { preset: 'vegan' } }"
+      class="order-vegan"
+    >
+      🥕 Vegan
+    </router-link><br>
+    <router-link
+      :to="{ name: 'order', params: { preset: 'meatlover' } }"
+      class="order-meatlover"
+    >
+      🍖 Meatlover
+    </router-link><br>
+    <router-link
+      :to="{ name: 'order', params: { preset: 'hawaian' } }"
+      class="order-hawaian"
+    >
+      🍍 Hawain
+    </router-link><br>
+    <router-link
+      :to="{ name: 'order', query: { cheese: true } }"
+      class="order-cheese"
+    >
+      🧀 Just Cheese
+    </router-link>
+  </div>
+</template>

--- a/components/PizzaShop/Order.vue
+++ b/components/PizzaShop/Order.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="pizza-order">
+    <router-link class="home" :to="{ name: 'home' }">Go Home</router-link><br>
+    <div class="toppings" style="float: left; width: 50%">
+      <h4>Select Your Toppings</h4>
+      <ul>
+        <li v-for="topping in toppings" :key="topping.name">
+          <input
+            type="checkbox"
+            :id="topping.name"
+            :value="topping"
+            v-model="selected"
+          >
+          <label :for="topping.name">
+            {{ topping.icon }} {{ topping.name }}
+          </label>
+        </li>
+      </ul>
+    </div>
+    <div class="order-overview" style="float: left; width: 50%">
+      <h4>Order Overview</h4>
+      <ul v-if="selected.length">
+        <li v-for="topping in selected" :key="topping.name">
+          {{ topping.icon }} {{ topping.name }}
+        </li>
+      </ul>
+      <div v-else>
+        👈 Select your toppings.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ALL_TOPPINGS, PRESETS } from './toppings'
+
+const filterByName = (list, name) =>
+  list.filter(i => i.name === name)
+
+export default {
+  data () {
+    return {
+      toppings: ALL_TOPPINGS,
+      selected: [],
+    }
+  },
+
+  methods: {
+    hasTopping (name) {
+      return !!filterByName(this.selected, name)[0]
+    },
+    getTopping (name) {
+      return filterByName(ALL_TOPPINGS, name)[0]
+    }
+  },
+
+  created () {
+    const presetName = this.$route.params.preset
+    this.selected = presetName ? PRESETS[presetName]: []
+
+    const selectedToppings = this.$route.query
+    for (const toppingName of Object.keys(selectedToppings)) {
+      if(selectedToppings[toppingName] && !this.hasTopping(toppingName)) {
+        const topping = this.getTopping(toppingName)
+        this.selected.push(topping)
+      }
+    }
+  }
+}
+</script>
+
+

--- a/components/PizzaShop/index.vue
+++ b/components/PizzaShop/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="pizza-shop">
+    <h2>Welcome to Cypress Pizza 🍕</h2>
+    <h3>Better Testing. Better Pizza. Cypress.io</h3>
+    <router-view />
+  </div>
+</template>

--- a/components/PizzaShop/router.js
+++ b/components/PizzaShop/router.js
@@ -1,0 +1,20 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+import PizzaShop from './index'
+import Home from './Home'
+import Order from './Order'
+
+Vue.use(VueRouter)
+
+export default new VueRouter({
+  routes: [
+    {
+      path: '/',
+      component: PizzaShop,
+      children: [
+        { path: '', name: 'home', component: Home },
+        { path: 'order/:preset?', name: 'order', component: Order }
+      ]
+    }
+  ]
+})

--- a/components/PizzaShop/toppings.js
+++ b/components/PizzaShop/toppings.js
@@ -1,0 +1,22 @@
+const CHEESE = { name: 'cheese', icon: '🧀' }
+const TOMATOES = { name: 'tomatoes', icon: '🍅' }
+const MUSHROOMS = { name: 'mushrooms', icon: '🍄' }
+const PEPPERS = { name: 'peppers', icon: '🌶' }
+const PINEAPPLE = { name: 'pineapple', icon: '🍍' }
+const CHICKEN = { name: 'chicken', icon: '🐔' }
+const STEAK = { name: 'steak', icon: '🐮' }
+const HAM = { name: 'ham', icon: '🐷' }
+const BACON = { name: 'bacon', icon: '🥓' }
+
+const veggie = [CHEESE, TOMATOES, MUSHROOMS, PEPPERS, PINEAPPLE]
+const vegan = [TOMATOES, MUSHROOMS, PEPPERS, PINEAPPLE]
+const meatlover = [CHEESE, CHICKEN, STEAK, HAM, BACON]
+const hawaian = [CHEESE, PINEAPPLE, HAM]
+
+export const ALL_TOPPINGS = [
+  CHEESE, TOMATOES, MUSHROOMS, PEPPERS,
+  PINEAPPLE, CHICKEN, STEAK, HAM, BACON
+]
+
+export const PRESETS = {veggie, vegan, meatlover, hawaian}
+

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
-  "viewportWidth": 300,
-  "viewportHeight": 100,
+  "viewportWidth": 500,
+  "viewportHeight": 500,
   "videoRecording": false,
   "projectId": "134ej7"
 }

--- a/cypress/integration/router-spec.js
+++ b/cypress/integration/router-spec.js
@@ -1,0 +1,98 @@
+import PizzaShop from '../../components/PizzaShop'
+import router from '../../components/PizzaShop/router'
+import VueRouter from 'vue-router'
+import mountVue from '../..'
+
+describe('Vue Router - Pizza Shop', () => {
+
+  // configure component
+  const extensions = {
+    plugins: [VueRouter],
+    components: {
+      PizzaShop
+    }
+  }
+
+  // define component template
+  const template = '<router-view />'
+
+  // initialize a fresh Vue app before each test
+  beforeEach(mountVue({ template, router }, { extensions }))
+
+  it('go to order page', () => {
+    cy.get('button.order').click()
+    cy.contains('Toppings')
+  })
+
+  it('order veggie option', () => {
+    // go back to home page
+    // from: /order -> to: /
+    cy.get('a.home').click()
+
+    // order a meatlover pizza
+    // to: /order/meatlover
+    cy.get('a.order-veggie').click()
+      .then(() => {
+        const { path, params } = Cypress.vue.$route
+        expect(path).to.eql('/order/veggie')
+        expect(params).to.eql({ preset: 'veggie' })
+      })
+
+    // veggie pizza shouldn't have any meat
+    // we wouldn't want a lawsuit
+    for (const topping of ['chicken', 'steak', 'bacon', 'ham']) {
+      cy.get('.order-overview > ul > li')
+        .should('not.contain', topping)
+    }
+  })
+
+  it('order meatlover option', () => {
+    // go back to home page
+    // from: /order/veggie -> to: /
+    cy.get('a.home').click()
+      .then(() => {
+        const { path, query, params } = Cypress.vue.$route
+        expect(path).to.eql('/')
+        expect(query).to.be.empty
+        expect(params).to.be.empty
+      })
+
+    // order a meatlover pizza
+    // to: /order/meatlover
+    cy.get('a.order-meatlover').click()
+      .then(() => {
+        const { path, params } = Cypress.vue.$route
+        expect(path).to.eql('/order/meatlover')
+        expect(params).to.eql({ preset: 'meatlover' })
+      })
+  })
+
+  it('order cheese option', () => {
+    // directly control the router from your test
+    cy.wrap(Cypress.vue.$router)
+      .then($router => $router.push({ name: 'home' }))
+
+    // order just a cheese
+    // to: /order?cheese=true
+    cy.get('a.order-cheese').click()
+      .then(() => {
+        const { path, query } = Cypress.vue.$route
+        expect(path).to.eql('/order')
+        expect(query).to.eql({ cheese: true })
+      })
+
+    // cheese topping should be in the order overview
+    cy.get('.order-overview > ul > li').contains('cheese')
+  })
+
+  it('order hawaian + peppers pizza without using UI', () => {
+    cy.wrap(Cypress.vue.$router)
+      .then($router => $router.push({ name: 'home' }))
+      .then($router => $router.push({
+        name: 'order',
+        params: { preset: 'hawaian' },
+        query: { peppers: true }
+      }))
+  })
+})
+

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "standard": "10.0.3",
     "vue": "2.5.13",
     "vue-loader": "13.6.1",
+    "vue-router": "3.0.1",
     "vue-template-compiler": "2.5.13"
   },
   "standard": {

--- a/preprocessor/webpack.js
+++ b/preprocessor/webpack.js
@@ -4,6 +4,9 @@ const webpackPreprocessor = require('@cypress/webpack-preprocessor')
 
 // default Cypress webpack options - good for basic projects
 const webpackOptions = {
+  resolve: {
+    extensions: ['.js', '.json', '.vue']
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Added a Pizza Shop example to demonstrate component unit-testing with Vue Router. 

**The example demonstrates:**
- `RouterLink`
- nested `RouterViews`
- making assertions against `Cypress.vue.$route` properties
- navigating **within tests** via `Cypress.vue.$router`

Closes bahmutov/cypress-vue-unit-test#14