### PR TITLE
WIP: create wrapper component with vue test-utils

### DIFF
--- a/cypress/integration/message-list-spec.js
+++ b/cypress/integration/message-list-spec.js
@@ -13,10 +13,11 @@ describe('MessageList', () => {
   })
 
   it('shows messages', () => {
-    Cypress.vue.messages = ['one', 'two']
+    Cypress.$vue.setProps({messages: ['one', 'two']}) // using vue-test-utils
+
     getItems().should('have.length', 2)
     cy.then(() => {
-      Cypress.vue.messages.push('three')
+      Cypress.vue.messages.push('three') // using the prop directly
       getItems().should('have.length', 3)
     })
   })

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,8 +17,8 @@ interface Options {
   html?: string;
   base?: string;
   extensions: {
-    components: any[];
-    filters: any[];
+    components: {[name: string]: any};
+    filters: {[name: string]: any};
     use: any[];
     plugins: any[];
     mixin: any[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,34 @@
+import Vue, { ComponentOptions } from "vue";
+
+declare global {
+  namespace Cypress {
+    import Vue from "vue";
+    import { Wrapper, VueClass } from '@vue/test-utils';
+
+    interface Cypress {
+      vue: Vue;
+      $vue: Wrapper<Vue>
+    }
+  }
+}
+
+interface Options {
+  mountId?: string;
+  html?: string;
+  base?: string;
+  extensions: {
+    components: any[];
+    filters: any[];
+    use: any[];
+    plugins: any[];
+    mixin: any[];
+    mixins: any[];
+  };
+}
+
+function mountVue<V extends Vue>(
+  component: Vue.VueConstructor,
+  optionsOrProps?: Options
+): () => void;
+
+export = mountVue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -671,6 +671,23 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@vue/test-utils": {
+      "version": "1.0.0-beta.30",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.30.tgz",
+      "integrity": "sha512-Wyvcha9fNk8+kzTDwb3xWGjPkCPzHSYSwKP6MplrPTG/auhqoad7JqUEceZLc6u7AU4km2pPQ8/m9s0RgCZ0NA==",
+      "requires": {
+        "dom-event-types": "^1.0.0",
+        "lodash": "^4.17.15",
+        "pretty": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -852,8 +869,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "abs": {
       "version": "1.3.13",
@@ -2961,6 +2977,43 @@
         "typedarray": "^0.0.6"
       }
     },
+    "condense-newlines": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz",
+      "integrity": "sha1-PemFVTE5R10yUCyDsC9gaE0kxV8=",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-whitespace": "^0.3.0",
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
@@ -3882,6 +3935,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-event-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz",
+      "integrity": "sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ=="
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -3930,6 +3988,33 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "electron-to-chromium": {
@@ -6167,8 +6252,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -6684,6 +6768,11 @@
         "unc-path-regex": "^0.1.2"
       }
     },
+    "is-whitespace": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
+      "integrity": "sha1-Fjnssb4DauxppUy7QBz77XEUq38="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -6740,6 +6829,18 @@
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.1.tgz",
       "integrity": "sha512-HbTaaXlIHoDVNXjmp4flOBWOfYBkrVN8dD1tp4m+95M/ADSDW/BxWbiwyVIhw/2+5d0cof4PHZCbE7+S1ukTQw==",
       "dev": true
+    },
+    "js-beautify": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
+      "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
+      "requires": {
+        "config-chain": "^1.1.12",
+        "editorconfig": "^0.15.3",
+        "glob": "^7.1.3",
+        "mkdirp": "~0.5.1",
+        "nopt": "~4.0.1"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -7940,7 +8041,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -11653,7 +11753,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -12386,6 +12485,26 @@
         }
       }
     },
+    "pretty": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz",
+      "integrity": "sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=",
+      "requires": {
+        "condense-newlines": "^0.2.1",
+        "extend-shallow": "^2.0.1",
+        "js-beautify": "^1.6.12"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "pretty-format": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
@@ -12450,6 +12569,11 @@
         "react-is": "^16.8.1"
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
     "protocols": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
@@ -12464,8 +12588,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.1.32",
@@ -13395,6 +13518,11 @@
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
       }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "files": [
     "src/*.js",
+    "index.d.ts",
     "preprocessor/*.js",
     "!src/*-spec.js"
   ],
@@ -39,6 +40,7 @@
   ],
   "license": "MIT",
   "main": "src/",
+  "types": "index.d.ts",
   "private": false,
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"
@@ -112,7 +114,6 @@
   "dependencies": {
     "@cypress/webpack-preprocessor": "2.0.1",
     "@kazupon/vue-i18n-loader": "0.3.0",
-    "@vue/test-utils": "1.0.0-beta.30",
     "common-tags": "1.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
   },
   "dependencies": {
     "@cypress/webpack-preprocessor": "2.0.1",
-    "common-tags": "1.8.0",
-    "@kazupon/vue-i18n-loader": "0.3.0"
+    "@kazupon/vue-i18n-loader": "0.3.0",
+    "@vue/test-utils": "1.0.0-beta.30",
+    "common-tags": "1.8.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const Vue = require('vue/dist/vue')
 const { stripIndent } = require('common-tags')
+const { createWrapper } = require('@vue/test-utils')
 
 // mountVue options
 const defaultOptions = ['html', 'vue', 'base', 'mountId', 'extensions']
@@ -201,7 +202,6 @@ const mountVue = (component, optionsOrProps = {}) => () => {
   installPlugins(Vue, options)
   registerGlobalComponents(Vue, options)
   deleteCachedConstructors(component)
-
   // create root Vue component
   // and make it accessible via Cypress.vue
   if (isConstructor(component)) {
@@ -212,6 +212,7 @@ const mountVue = (component, optionsOrProps = {}) => () => {
     Cypress.vue = new Vue(component).$mount(el)
     copyStyles(component)
   }
+  Cypress.$vue = createWrapper(Cypress.vue)
 
   return cy
     .window({ log: false })


### PR DESCRIPTION
I'm proposing creating a wrapper with vue-test-utils to use the utilities included with it. I'm not changing how the component is mounted, although it seems like we could do that to and remove some of the code included in this.

Is there a reason to avoid using vue-test-utils and cypress-vue-unit-test in tandem?