### PR TITLE
fix message-spec for cypress 4.0.0 breaking changes

### DIFF
--- a/cypress/integration/message-spec.js
+++ b/cypress/integration/message-spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import Message from '../../components/Message.vue'
 const mountVue = require('../..')
 

--- a/cypress/integration/message-spec.js
+++ b/cypress/integration/message-spec.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import Message from '../../components/Message.vue'
 const mountVue = require('../..')
 
@@ -42,8 +44,8 @@ describe('Message', () => {
       })
 
       it('message has at least length 2', () => {
-        expect(message.validator && message.validator('a')).to.be.falsy
-        expect(message.validator && message.validator('aa')).to.be.truthy
+        expect(message.validator && message.validator('a')).to.be.not.ok
+        expect(message.validator && message.validator('aa')).to.be.ok
       })
     })
   })
@@ -64,7 +66,7 @@ describe('Message', () => {
         const stub = cy.spy()
         Cypress.vue.$on('message-clicked', stub)
         cy.get('.message').click().then(() => {
-          expect(stub).to.be.called.once
+          expect(stub).to.be.calledOnce
           expect(stub).to.be.calledWith('Cat')
         })
       })


### PR DESCRIPTION
since invalid chai properties now error, this test started failing in 4.0.

- fix invalid chai assertions