### PR TITLE
fix: double Vue initialization -- require peer dep for Vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19358,12 +19358,6 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
-    "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
-      "dev": true
-    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "simple-commit-message": "4.0.13",
     "standard": "12.0.1",
     "tailwindcss": "1.1.4",
-    "vue": "2.6.10",
+    "vue": "2.x",
     "vue-i18n": "7.8.1",
     "vue-loader": "14.2.4",
     "vue-router": "3.0.5",
@@ -108,7 +108,7 @@
     ]
   },
   "peerDependencies": {
-    "vue": "2",
+    "vue": "2.x",
     "cypress": "*"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-const Vue = require('vue/dist/vue')
+const Vue = require('vue').default
 const { stripIndent } = require('common-tags')
 
 // mountVue options


### PR DESCRIPTION
This fix enables the user to define whatever version of Vue 2.x they'd like.

Currently, errors are thrown when a page contains multiple versions of VueRouter. This is fixed by sharing the Vue instance across the spec files and the framework code. This is achieved by making Vue a peer dependency and removing it from dev dependencies.

This error also revealed the need for a bundling process, as it is possible to use devDependencies accidentally.