### PR TITLE
fix: Issue #305 force the compiler only build to support template options

### DIFF
--- a/preprocessor/webpack.js
+++ b/preprocessor/webpack.js
@@ -46,8 +46,7 @@ function inlineUrlLoadedAssets (options = {}) {
 function compileTemplate (options = {}) {
   options.resolve = options.resolve || {}
   options.resolve.alias = options.resolve.alias || {}
-  options.resolve.alias['vue$'] =
-    options.resolve.alias['vue$'] || 'vue/dist/vue.esm.js'
+  options.resolve.alias['vue$'] = 'vue/dist/vue.esm.js'
 }
 inlineUrlLoadedAssets(webpackOptions)
 preventChunking(webpackOptions)


### PR DESCRIPTION
Fixes issue #305 and forces the runtime + compiler build to be imported when `import 'vue'` is called