### PR TITLE
Mocking axios example

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,7 @@ Spec | Description
 <!-- prettier-ignore-start -->
 Spec | Description
 --- | ---
+[mocking-axios](cypress/component/advanced/mocking-axios) | Mocking 3rd party module imports, like `axios` for fetching data
 [mocking-components](cypress/component/advanced/mocking-components) | Mocking locally registered child components during tests
 [mocking-imports](cypress/component/advanced/mocking-imports) | Stub ES6 imports from the tests
 [render-functions](cypress/component/advanced/render-functions) | Mounting components with a [render function](https://www.tutorialandexample.com/vue-js-render-functions/)

--- a/cypress/component/advanced/mocking-axios/AxiosGet.vue
+++ b/cypress/component/advanced/mocking-axios/AxiosGet.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <h1>Axios Get</h1>
+    <ul v-if="users && users.length">
+      <li v-for="user of users" v-bind:key="user.id">
+        <p><strong>{{user.id}}</strong> - {{user.name}}</p>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+// import just the "get" from axios
+import {get} from 'axios';
+import * as Axios from 'axios';
+
+export default {
+  data() {
+    return {
+      users: []
+    }
+  },
+
+  // Fetches posts when the component is created.
+  created() {
+    console.log('get is', get)
+    console.log('Axios is', Axios)
+
+    Axios.get('https://jsonplaceholder.cypress.io/users?_limit=3')
+    .then(response => {
+      // JSON responses are automatically parsed.
+      this.users = response.data
+    })
+  }
+}
+</script>

--- a/cypress/component/advanced/mocking-axios/AxiosGet.vue
+++ b/cypress/component/advanced/mocking-axios/AxiosGet.vue
@@ -14,6 +14,8 @@
 import {get} from 'axios';
 import * as Axios from 'axios';
 
+window.AxiosLib = Axios
+
 export default {
   data() {
     return {

--- a/cypress/component/advanced/mocking-axios/AxiosGetRequire.vue
+++ b/cypress/component/advanced/mocking-axios/AxiosGetRequire.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <h1>Axios Get</h1>
+    <ul v-if="users && users.length">
+      <li v-for="user of users" v-bind:key="user.id">
+        <p><strong>{{user.id}}</strong> - {{user.name}}</p>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+const Axios = require('axios')
+
+window.AxiosLib = Axios
+
+export default {
+  data() {
+    return {
+      users: []
+    }
+  },
+
+  // Fetches posts when the component is created.
+  created() {
+    console.log('get is', get)
+    console.log('Axios is', Axios)
+
+    Axios.get('https://jsonplaceholder.cypress.io/users?_limit=3')
+    .then(response => {
+      // JSON responses are automatically parsed.
+      this.users = response.data
+    })
+  }
+}
+</script>

--- a/cypress/component/advanced/mocking-axios/README.md
+++ b/cypress/component/advanced/mocking-axios/README.md
@@ -1,1 +1,7 @@
 # mocking axios
+
+**Help wanted**
+
+How can `import ... from '...'` be mocked from Vue and from JS spec files? In plain JS files we use '@babel/plugin-transform-modules-commonjs' plugin so that all imports from file X are the same object and the individual properties can be stubbed using `cy.stub(X, 'import name')`. But the `vue-loader` used to transpile Vue files seems to not allow additional Babel plugins?
+
+See [mock-get-spec.js](mock-get-spec.js) and [AxiosGet.vue](AxiosGet.vue) for an open problem.

--- a/cypress/component/advanced/mocking-axios/README.md
+++ b/cypress/component/advanced/mocking-axios/README.md
@@ -1,0 +1,1 @@
+# mocking axios

--- a/cypress/component/advanced/mocking-axios/mock-get-require-spec.js
+++ b/cypress/component/advanced/mocking-axios/mock-get-require-spec.js
@@ -1,12 +1,10 @@
 /// <reference types="cypress" />
 import { mount } from 'cypress-vue-unit-test'
 import AxiosGet from './AxiosGet.vue'
+// can we mock module loaded using "require"?
+const Axios = require('axios')
 
-// import everything from "axios" module
-// so we can mock its methods from the test
-import * as Axios from 'axios'
-
-describe('Mocking get import from Axios', () => {
+describe('Mocking get require from Axios', () => {
   // https://github.com/bahmutov/cypress-vue-unit-test/issues/346
   it.skip('renders mocked data', () => {
     cy.stub(Axios, 'get')

--- a/cypress/component/advanced/mocking-axios/mock-get-spec.js
+++ b/cypress/component/advanced/mocking-axios/mock-get-spec.js
@@ -1,0 +1,25 @@
+/// <reference types="cypress" />
+import { mount } from 'cypress-vue-unit-test'
+import AxiosGet from './AxiosGet.vue'
+
+// import everything from "axios" module
+// so we can mock its methods from the test
+import * as Axios from 'axios'
+
+describe('Mocking get import from Axios', () => {
+  it('renders mocked data', () => {
+    cy.stub(Axios, 'get')
+      .resolves({
+        data: [
+          {
+            id: 101,
+            name: 'Test User',
+          },
+        ],
+      })
+      .as('get')
+
+    console.log('Axios is', Axios)
+    mount(AxiosGet)
+  })
+})

--- a/cypress/component/advanced/mocking-axios/mock-get-spec.js
+++ b/cypress/component/advanced/mocking-axios/mock-get-spec.js
@@ -20,6 +20,8 @@ describe('Mocking get import from Axios', () => {
       .as('get')
 
     console.log('Axios is', Axios)
+    console.log('window.AxiosLib is', window.AxiosLib)
+    console.log('window.AxiosLib === Axios?', window.AxiosLib === Axios)
     mount(AxiosGet)
   })
 })


### PR DESCRIPTION
Trying to show an example of mocking 3rd party commonjs module like Axios for #346 

For now the axios module is different between the Vue component and the spec file

```
  cypress-vue-unit-test adding code coverage plugin +0ms
  cypress-vue-unit-test found plugin VueLoaderPlugin already +1ms
final webpack
{
  resolve: {
    extensions: [ '.js', '.json', '.vue' ],
    alias: {
      'cypress-vue-unit-test': '/Users/gleb/git/cypress-vue-unit-test/dist',
      'vue$': 'vue/dist/vue.esm.js'
    }
  },
  module: {
    rules: [
      {
        test: /\.vue$/,
        loader: 'vue-loader',
        options: { loaders: { i18n: '@kazupon/vue-i18n-loader' } }
      },
      { test: /\.css$/, use: [ 'vue-style-loader', 'css-loader' ] },
      {
        test: /\.js$/,
        loader: 'babel-loader',
        exclude: /node_modules/,
        options: {
          plugins: [
            [
              '@babel/plugin-transform-modules-commonjs',
              { loose: true }
            ],
            [
              'babel-plugin-istanbul',
              { extension: [ '.js', '.vue' ] }
            ]
          ]
        }
      }
    ]
  },
  plugins: [
    VueLoaderPlugin {},
    LimitChunkCountPlugin { options: { maxChunks: 1 } }
  ],
  mode: 'development',
  devtool: '#eval-source-map'
}
```

Seems the 3rd party module is different between the spec and the module ☹️